### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "java10"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-![FredBoat](https://fred.moe/YY1.png)
-
+[![Run on Repl.it](https://repl.it/badge/github/masonafaw/musicbot2)](https://repl.it/github/masonafaw/musicbot2)
 # FredBoat [![TeamCity (simple build status)](https://img.shields.io/teamcity/https/ci.fredboat.com/s/FredBoat_Build.svg)](https://ci.fredboat.com/viewType.html?buildTypeId=FredBoat_Build&guest=1) [![Github commits (since latest release)](https://img.shields.io/github/commits-since/Frederikam/FredBoat/latest.svg)]() [![Crowdin](https://d322cqt584bo4o.cloudfront.net/fredboat/localized.svg)](https://crowdin.com/project/fredboat) [![Open Source Helpers](https://www.codetriage.com/frederikam/fredboat/badges/users.svg)](https://www.codetriage.com/frederikam/fredboat) [![Twitter Follow](https://img.shields.io/twitter/follow/DiscordFredBoat.svg?style=social&label=Follow)]()
 FredBoat is a bot that has various features, but most notably is that it can play music. Pull requests are welcome and please report any issues you find in [issues](https://github.com/Frederikam/FredBoat/issues).
 


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).